### PR TITLE
Fix hash casting bug in participant color utility

### DIFF
--- a/src/utils/participantColors.ts
+++ b/src/utils/participantColors.ts
@@ -20,7 +20,8 @@ function hashString(str: string): number {
   for (let i = 0; i < str.length; i++) {
     const char = str.charCodeAt(i);
     hash = ((hash << 5) - hash) + char;
-    hash = hash & hash; // Convert to 32bit integer
+    // Convert to 32bit integer
+    hash |= 0;
   }
   return Math.abs(hash);
 }


### PR DESCRIPTION
## Summary
- ensure the color hashing uses a proper 32‑bit integer conversion

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866ec5aa6a88333aef60aa62e41c9d2