### PR TITLE
Add vitest test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## How do I run tests?
+
+Run the test suite with:
+
+```sh
+npm test
+```
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/eb3e9acc-52ee-47ef-a8c9-620669ee476b) and click on Share -> Publish.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -75,6 +76,8 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^15.0.0"
   }
 }

--- a/src/contexts/QuizContext.test.tsx
+++ b/src/contexts/QuizContext.test.tsx
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { generateRoomId } from './QuizContext';
+
+describe('generateRoomId', () => {
+  it('returns a 6 character string', () => {
+    const id = generateRoomId();
+    expect(typeof id).toBe('string');
+    expect(id).toHaveLength(6);
+  });
+});


### PR DESCRIPTION
## Summary
- add basic test script and vitest dependencies
- test generateRoomId() with Vitest
- document how to run tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866eea55e0c83338c7a729d536fd5b7