### PR TITLE
Fix host identify message

### DIFF
--- a/party/server.ts
+++ b/party/server.ts
@@ -51,8 +51,8 @@ function isQuizMessage(msg: any): msg is QuizMessage {
   switch (msg.type) {
     case 'identify':
       return (
-        typeof msg.name === 'string' &&
-        typeof msg.isHost === 'boolean'
+        typeof msg.isHost === 'boolean' &&
+        (msg.isHost || typeof msg.name === 'string')
       );
     case 'addQuestion':
       return typeof msg.question === 'object' && typeof msg.question.id === 'string';


### PR DESCRIPTION
## Summary
- adjust server-side message validation so host identification does not require a name

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686729e6ce608333b9e5a83e7235c29e