### PR TITLE
Add optional graded questions and fix answer evaluation

### DIFF
--- a/party/server.ts
+++ b/party/server.ts
@@ -7,6 +7,7 @@ export interface Question {
   type: 'single-choice' | 'multi-choice' | 'text-input';
   options?: string[];
   correctAnswers?: string[];
+  graded?: boolean;
 }
 
 // Define the shape of a participant

--- a/src/components/HostRoom.tsx
+++ b/src/components/HostRoom.tsx
@@ -15,7 +15,8 @@ export default function HostRoom() {
     text: '',
     type: 'single-choice',
     options: ['', ''],
-    correctAnswers: []
+    correctAnswers: [],
+    graded: false
   });
 
   const handleAddQuestion = () => {
@@ -27,7 +28,8 @@ export default function HostRoom() {
         options: newQuestion.type !== 'text-input'
           ? newQuestion.options?.filter(opt => opt.trim())
           : undefined,
-        correctAnswers: newQuestion.correctAnswers?.filter(a => a.trim())
+        correctAnswers: newQuestion.correctAnswers?.filter(a => a.trim()),
+        graded: newQuestion.graded
       };
 
       send({ type: 'addQuestion', question });
@@ -35,7 +37,8 @@ export default function HostRoom() {
         text: '',
         type: 'single-choice',
         options: ['', ''],
-        correctAnswers: []
+        correctAnswers: [],
+        graded: false
       });
     }
   };
@@ -140,15 +143,15 @@ export default function HostRoom() {
                     <label className="block text-lg font-semibold mb-3 text-foreground">
                       Tipo
                     </label>
-                    <Select
-                      value={newQuestion.type}
-                      onValueChange={(value) => setNewQuestion({
-                        ...newQuestion,
-                        type: value as Question['type'],
-                        options: value !== 'text-input' ? ['', ''] : undefined,
-                        correctAnswers: []
-                      })}
-                    >
+                  <Select
+                    value={newQuestion.type}
+                    onValueChange={(value) => setNewQuestion({
+                      ...newQuestion,
+                      type: value as Question['type'],
+                      options: value !== 'text-input' ? ['', ''] : undefined,
+                      correctAnswers: []
+                    })}
+                  >
                       <SelectTrigger className="text-lg py-4 px-6 rounded-2xl border-2">
                         <SelectValue />
                       </SelectTrigger>
@@ -157,8 +160,23 @@ export default function HostRoom() {
                         <SelectItem value="multi-choice">Múltiplas Escolhas</SelectItem>
                         <SelectItem value="text-input">Resposta Livre</SelectItem>
                       </SelectContent>
-                    </Select>
+                  </Select>
+                  <div className="flex items-center gap-3 mt-4">
+                    <input
+                      type="checkbox"
+                      className="h-5 w-5 text-primary"
+                      checked={newQuestion.graded}
+                      onChange={(e) =>
+                        setNewQuestion({
+                          ...newQuestion,
+                          graded: e.target.checked,
+                          correctAnswers: []
+                        })
+                      }
+                    />
+                    <span className="text-lg">Habilitar resposta correta</span>
                   </div>
+                </div>
 
                   {newQuestion.type !== 'text-input' && (
                     <div>
@@ -168,33 +186,35 @@ export default function HostRoom() {
                       <div className="space-y-3">
                         {newQuestion.options?.map((option, index) => (
                           <div key={index} className="flex gap-3 items-center">
-                            {newQuestion.type === 'single-choice' ? (
-                              <input
-                                type="radio"
-                                className="h-5 w-5 text-primary"
-                                checked={newQuestion.correctAnswers?.[0] === option}
-                                onChange={() =>
-                                  setNewQuestion({
-                                    ...newQuestion,
-                                    correctAnswers: [option]
-                                  })
-                                }
-                              />
-                            ) : (
-                              <input
-                                type="checkbox"
-                                className="h-5 w-5 text-primary"
-                                checked={newQuestion.correctAnswers?.includes(option)}
-                                onChange={() => {
-                                  const exists = newQuestion.correctAnswers?.includes(option);
-                                  setNewQuestion({
-                                    ...newQuestion,
-                                    correctAnswers: exists
-                                      ? newQuestion.correctAnswers?.filter(a => a !== option)
-                                      : [...(newQuestion.correctAnswers || []), option]
-                                  });
-                                }}
-                              />
+                            {newQuestion.graded && (
+                              newQuestion.type === 'single-choice' ? (
+                                <input
+                                  type="radio"
+                                  className="h-5 w-5 text-primary"
+                                  checked={newQuestion.correctAnswers?.[0] === option}
+                                  onChange={() =>
+                                    setNewQuestion({
+                                      ...newQuestion,
+                                      correctAnswers: [option]
+                                    })
+                                  }
+                                />
+                              ) : (
+                                <input
+                                  type="checkbox"
+                                  className="h-5 w-5 text-primary"
+                                  checked={newQuestion.correctAnswers?.includes(option)}
+                                  onChange={() => {
+                                    const exists = newQuestion.correctAnswers?.includes(option);
+                                    setNewQuestion({
+                                      ...newQuestion,
+                                      correctAnswers: exists
+                                        ? newQuestion.correctAnswers?.filter(a => a !== option)
+                                        : [...(newQuestion.correctAnswers || []), option]
+                                    });
+                                  }}
+                                />
+                              )
                             )}
                             <Input
                               value={option}
@@ -225,7 +245,7 @@ export default function HostRoom() {
                     </div>
                   )}
 
-                  {newQuestion.type === 'text-input' && (
+                  {newQuestion.type === 'text-input' && newQuestion.graded && (
                     <div>
                       <label className="block text-lg font-semibold mb-3 text-foreground">
                         Resposta Correta
@@ -246,12 +266,12 @@ export default function HostRoom() {
 
                   <button
                     onClick={handleAddQuestion}
-                    disabled={
-                      !newQuestion.text?.trim() ||
-                      (newQuestion.type !== 'text-input' &&
-                        (!newQuestion.options || newQuestion.options.filter(opt => opt.trim()).length < 2)) ||
-                      !newQuestion.correctAnswers || newQuestion.correctAnswers.length === 0
-                    }
+                  disabled={
+                    !newQuestion.text?.trim() ||
+                    (newQuestion.type !== 'text-input' &&
+                      (!newQuestion.options || newQuestion.options.filter(opt => opt.trim()).length < 2)) ||
+                      (newQuestion.graded && (!newQuestion.correctAnswers || newQuestion.correctAnswers.length === 0))
+                  }
                     className="btn-primary w-full text-lg py-4 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
                   >
                     Adicionar Pergunta

--- a/src/components/ParticipantRoom.tsx
+++ b/src/components/ParticipantRoom.tsx
@@ -8,8 +8,9 @@ import { debug } from '../utils/debug';
 
 function arraysEqual(a: string[] = [], b: string[] = []) {
   if (a.length !== b.length) return false;
-  const sortedA = [...a].map(v => v.trim()).sort();
-  const sortedB = [...b].map(v => v.trim()).sort();
+  const normalize = (arr: string[]) => arr.map(v => v.trim().toLowerCase()).sort();
+  const sortedA = normalize(a);
+  const sortedB = normalize(b);
   return sortedA.every((v, i) => v === sortedB[i]);
 }
 export default function ParticipantRoom() {
@@ -91,7 +92,7 @@ export default function ParticipantRoom() {
       }
     });
 
-    if (currentQuestion.correctAnswers && currentQuestion.correctAnswers.length > 0) {
+    if (currentQuestion.graded && currentQuestion.correctAnswers && currentQuestion.correctAnswers.length > 0) {
       const correct = arraysEqual(answers, currentQuestion.correctAnswers);
       setAnswerResult(correct ? 'correct' : 'incorrect');
     }
@@ -185,7 +186,7 @@ export default function ParticipantRoom() {
                 <div className="space-y-3 mb-4">
                   {currentQuestion.options?.map((option, index) => {
                     const isSelected = selectedOptionIndexes.includes(index);
-                    const correct = currentQuestion.correctAnswers?.includes(option.trim());
+                    const correct = currentQuestion.graded && currentQuestion.correctAnswers?.includes(option.trim());
                     const color = isSelected ? (answerResult === 'correct' ? 'border-success bg-success/20' : 'border-destructive bg-destructive/20') : 'border-border';
                     const textColor = isSelected ? (answerResult === 'correct' ? 'text-success' : 'text-destructive') : '';
                     return (

--- a/src/components/QuestionManager.tsx
+++ b/src/components/QuestionManager.tsx
@@ -69,7 +69,7 @@ export default function QuestionManager() {
                     ))}
                   </div>
                 )}
-                {question.correctAnswers && question.correctAnswers.length > 0 && (
+                {question.graded && question.correctAnswers && question.correctAnswers.length > 0 && (
                   <p className="text-sm mt-2 text-muted-foreground">
                     Resposta correta: {question.correctAnswers.join(', ')}
                   </p>

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -3,8 +3,9 @@ import { useQuiz } from '../contexts/QuizContext';
 
 function arraysEqual(a: string[] = [], b: string[] = []) {
   if (a.length !== b.length) return false;
-  const sortedA = [...a].sort();
-  const sortedB = [...b].sort();
+  const normalize = (arr: string[]) => arr.map(v => v.trim().toLowerCase()).sort();
+  const sortedA = normalize(a);
+  const sortedB = normalize(b);
   return sortedA.every((v, i) => v === sortedB[i]);
 }
 
@@ -18,7 +19,7 @@ export default function ScoreBoard() {
   if (participantId) {
     serverState.questions.forEach(q => {
       const ans = serverState.answers[q.id]?.[participantId];
-      if (ans && q.correctAnswers && q.correctAnswers.length > 0) {
+      if (ans && q.graded && q.correctAnswers && q.correctAnswers.length > 0) {
         if (arraysEqual(ans, q.correctAnswers)) correct++; else wrong++;
       }
     });


### PR DESCRIPTION
## Summary
- support optional graded questions via new `graded` property
- show toggle when creating a question to enable grading
- only display correct answers and compute scores for graded questions
- normalize comparisons when evaluating answers to fix mismatch bug

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68672f34c10083338955005cb2b6c486