### PR TITLE
Fix accent-insensitive answer comparison

### DIFF
--- a/src/components/ParticipantRoom.tsx
+++ b/src/components/ParticipantRoom.tsx
@@ -4,15 +4,7 @@ import { Textarea } from './ui/textarea';
 import { getParticipantColor } from '../utils/participantColors';
 import ScoreBoard from './ScoreBoard';
 import { debug } from '../utils/debug';
-
-
-function arraysEqual(a: string[] = [], b: string[] = []) {
-  if (a.length !== b.length) return false;
-  const normalize = (arr: string[]) => arr.map(v => v.trim().toLowerCase()).sort();
-  const sortedA = normalize(a);
-  const sortedB = normalize(b);
-  return sortedA.every((v, i) => v === sortedB[i]);
-}
+import { arraysEqual } from '../utils/answerUtils';
 export default function ParticipantRoom() {
 
   const { 

--- a/src/components/ScoreBoard.tsx
+++ b/src/components/ScoreBoard.tsx
@@ -1,13 +1,6 @@
 import React from 'react';
 import { useQuiz } from '../contexts/QuizContext';
-
-function arraysEqual(a: string[] = [], b: string[] = []) {
-  if (a.length !== b.length) return false;
-  const normalize = (arr: string[]) => arr.map(v => v.trim().toLowerCase()).sort();
-  const sortedA = normalize(a);
-  const sortedB = normalize(b);
-  return sortedA.every((v, i) => v === sortedB[i]);
-}
+import { arraysEqual } from '../utils/answerUtils';
 
 export default function ScoreBoard() {
   const { serverState, clientState } = useQuiz();

--- a/src/utils/answerUtils.ts
+++ b/src/utils/answerUtils.ts
@@ -1,0 +1,19 @@
+// Utility functions for comparing quiz answers
+
+// Normalize a string: trim, lowercase, remove diacritics
+export function normalizeAnswer(str: string): string {
+  return str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase();
+}
+
+// Compare two arrays of answers ignoring order, case and accents
+export function arraysEqual(a: string[] = [], b: string[] = []): boolean {
+  if (a.length !== b.length) return false;
+  const normalize = (arr: string[]) => arr.map(normalizeAnswer).sort();
+  const sortedA = normalize(a);
+  const sortedB = normalize(b);
+  return sortedA.every((v, i) => v === sortedB[i]);
+}


### PR DESCRIPTION
## Summary
- add answerUtils utility for accent-insensitive comparison
- use new arraysEqual in ParticipantRoom and ScoreBoard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686735ed9a108333ab7dada041aaefe4