### PR TITLE
Add question mid-quiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Key Features
+
+- Real-time interactive quiz
+- Export of results in multiple formats
+- **Add new questions even after the quiz has started**
+
 ## How do I run tests?
 
 Run the test suite with:

--- a/src/components/HostRoom.tsx
+++ b/src/components/HostRoom.tsx
@@ -119,8 +119,8 @@ export default function HostRoom() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* Left Column - Question Management */}
           <div className="lg:col-span-2 space-y-8">
-            {/* Create New Question */}
-            {!serverState.isQuizStarted && (
+            {/* Create New Question - now available even after the quiz starts */}
+            {!serverState.isQuizFinished && (
               <div className="card-modern animate-scale-in">
                 <h2 className="text-2xl font-bold mb-6 text-foreground">
                   Nova Pergunta


### PR DESCRIPTION
## Summary
- allow hosts to add questions even after the quiz starts
- document the feature in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68673ce229f4833390b51c5db4fa360c